### PR TITLE
craig/get_previous_revisions (#14)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 Revision history for App-Config
 
 {{$NEXT}}
+    Implemented new storage system based on key-values pairs instead of monolithic tree structure
+    Implemented new API
+    Implemented support for setting up Redis subscriptions
 
 0.06      2017-02-14 00:19:43+00:00 UTC
     Manage version with dzil

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -7,69 +7,64 @@ use 5.014;
 use ExtUtils::MakeMaker 6.48;
 
 my %WriteMakefileArgs = (
-  "ABSTRACT" => "Provides Data::Chronicle-backed configuration storage",
-  "AUTHOR" => "binary.com <cpan\@binary.com>",
-  "CONFIGURE_REQUIRES" => {
-    "ExtUtils::MakeMaker" => "6.48"
-  },
-  "DISTNAME" => "App-Config-Chronicle",
-  "LICENSE" => "perl",
-  "MIN_PERL_VERSION" => "5.014",
-  "NAME" => "App::Config::Chronicle",
-  "PREREQ_PM" => {
-    "Data::Chronicle::Reader" => 0,
-    "Data::Chronicle::Writer" => 0,
-    "Data::Hash::DotNotation" => 0,
-    "Date::Utility" => 0,
-    "JSON::XS" => 0,
-    "Moose" => 0,
-    "Time::HiRes" => 0,
-    "YAML::XS" => 0,
-    "namespace::autoclean" => 0
-  },
-  "TEST_REQUIRES" => {
-    "ExtUtils::MakeMaker" => 0,
-    "File::Spec" => 0,
-    "IO::Handle" => 0,
-    "IPC::Open3" => 0,
-    "Test::CheckDeps" => "0.010",
-    "Test::MockObject" => 0,
-    "Test::More" => "0.98"
-  },
-  "VERSION" => "0.06",
-  "test" => {
-    "TESTS" => "t/*.t"
-  }
-);
-
+    "ABSTRACT"           => "Provides Data::Chronicle-backed configuration storage",
+    "AUTHOR"             => "binary.com <cpan\@binary.com>",
+    "CONFIGURE_REQUIRES" => {"ExtUtils::MakeMaker" => "6.48"},
+    "DISTNAME"           => "App-Config-Chronicle",
+    "LICENSE"            => "perl",
+    "MIN_PERL_VERSION"   => "5.014",
+    "NAME"               => "App::Config::Chronicle",
+    "PREREQ_PM"          => {
+        "Data::Chronicle::Reader" => 0.18,
+        "Data::Chronicle::Writer" => 0.18,
+        "Data::Hash::DotNotation" => 0,
+        "Date::Utility"           => 0,
+        "JSON::XS"                => 0,
+        "Moose"                   => 0,
+        "Time::HiRes"             => 0,
+        "List::Util"              => 1.29,
+        "YAML::XS"                => 0,
+        "namespace::autoclean"    => 0
+    },
+    "TEST_REQUIRES" => {
+        "ExtUtils::MakeMaker" => 0,
+        "File::Spec"          => 0,
+        "IO::Handle"          => 0,
+        "IPC::Open3"          => 0,
+        "Test::CheckDeps"     => "0.010",
+        "Test::MockObject"    => 0,
+        "Test::More"          => "0.98"
+    },
+    "VERSION" => "0.07",
+    "test"    => {"TESTS" => "t/*.t"});
 
 my %FallbackPrereqs = (
-  "Data::Chronicle::Reader" => 0,
-  "Data::Chronicle::Writer" => 0,
-  "Data::Hash::DotNotation" => 0,
-  "Date::Utility" => 0,
-  "ExtUtils::MakeMaker" => 0,
-  "File::Spec" => 0,
-  "IO::Handle" => 0,
-  "IPC::Open3" => 0,
-  "JSON::XS" => 0,
-  "Moose" => 0,
-  "Test::CheckDeps" => "0.010",
-  "Test::MockObject" => 0,
-  "Test::More" => "0.98",
-  "Time::HiRes" => 0,
-  "YAML::XS" => 0,
-  "namespace::autoclean" => 0
+    "Data::Chronicle::Reader" => 0.18,
+    "Data::Chronicle::Writer" => 0.18,
+    "Data::Hash::DotNotation" => 0,
+    "Date::Utility"           => 0,
+    "ExtUtils::MakeMaker"     => 0,
+    "File::Spec"              => 0,
+    "IO::Handle"              => 0,
+    "IPC::Open3"              => 0,
+    "JSON::XS"                => 0,
+    "Moose"                   => 0,
+    "Test::CheckDeps"         => "0.010",
+    "Test::MockObject"        => 0,
+    "Test::More"              => "0.98",
+    "Time::HiRes"             => 0,
+    "List::Util"              => 1.29,
+    "YAML::XS"                => 0,
+    "namespace::autoclean"    => 0
 );
 
-
-unless ( eval { ExtUtils::MakeMaker->VERSION(6.63_03) } ) {
-  delete $WriteMakefileArgs{TEST_REQUIRES};
-  delete $WriteMakefileArgs{BUILD_REQUIRES};
-  $WriteMakefileArgs{PREREQ_PM} = \%FallbackPrereqs;
+unless (eval { ExtUtils::MakeMaker->VERSION(6.63_03) }) {
+    delete $WriteMakefileArgs{TEST_REQUIRES};
+    delete $WriteMakefileArgs{BUILD_REQUIRES};
+    $WriteMakefileArgs{PREREQ_PM} = \%FallbackPrereqs;
 }
 
 delete $WriteMakefileArgs{CONFIGURE_REQUIRES}
-  unless eval { ExtUtils::MakeMaker->VERSION(6.52) };
+    unless eval { ExtUtils::MakeMaker->VERSION(6.52) };
 
 WriteMakefile(%WriteMakefileArgs);

--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ The configuration file is a YAML file. Here is an example:
           isa: Str
           default: "dummy@mail.com"
           global: 1
+        refresh:
+          description: "System refresh rate"
+          isa: Num
+          default: 10
+          global: 1
         admins:
           description: "Are we on Production?"
           isa: ArrayRef

--- a/cpanfile
+++ b/cpanfile
@@ -1,11 +1,11 @@
 requires 'perl', '5.014';
 
-requires 'Data::Chronicle::Reader';
-requires 'Data::Chronicle::Writer';
+requires 'Data::Chronicle', '>= 0.18';
 requires 'Data::Hash::DotNotation';
 requires 'JSON::MaybeXS';
 requires 'Moose';
 requires 'Time::HiRes';
+requires 'List::Util', '>= 1.29';
 requires 'Date::Utility';
 requires 'YAML::XS';
 requires 'namespace::autoclean';
@@ -14,6 +14,7 @@ on test => sub {
     requires 'Test::MockObject';
     requires 'Test::More', '>= 0.98';
     requires 'Test::NoWarnings';
+    requires 'Test::MockTime';
 };
 
 on develop => sub {

--- a/lib/App/Config/Chronicle.pm
+++ b/lib/App/Config/Chronicle.pm
@@ -4,14 +4,11 @@ package App::Config::Chronicle;
 use strict;
 use warnings;
 use Time::HiRes qw(time);
+use List::Util qw(any pairs pairmap);
 
 =head1 NAME
 
 App::Config::Chronicle - An OO configuration module which can be changed and stored into chronicle database.
-
-=head1 VERSION
-
-Version 0.05
 
 =cut
 
@@ -39,6 +36,11 @@ The configuration file is a YAML file. Here is an example:
           isa: Str
           default: "dummy@mail.com"
           global: 1
+        refresh:
+          description: "System refresh rate"
+          isa: Num
+          default: 10
+          global: 1
         admins:
           description: "Are we on Production?"
           isa: ArrayRef
@@ -46,7 +48,7 @@ The configuration file is a YAML file. Here is an example:
 
 Every attribute is very intuitive. If an item is global, you can change its value and the value will be stored into chronicle database by calling the method C<save_dynamic>.
 
-=head1 SUBROUTINES/METHODS
+=head1 SUBROUTINES/METHODS (LEGACY)
 
 =cut
 
@@ -60,6 +62,15 @@ use Data::Hash::DotNotation;
 
 use Data::Chronicle::Reader;
 use Data::Chronicle::Writer;
+use Data::Chronicle::Subscriber;
+
+=head2 REDIS_HISTORY_TTL
+
+The maximum length of time (in seconds) that a cached history entry will stay in Redis.
+
+=cut
+
+use constant REDIS_HISTORY_TTL => 7 * 86400;    # 7 days
 
 =head2 definition_yml
 
@@ -99,11 +110,23 @@ has chronicle_writer => (
     required => 1,
 );
 
+=head2 chronicle_subscriber
+
+The chronicle connection that can notify via callbacks when particular configuration items have a new value set. It should be an instance of L<Data::Chronicle::Subscriber>.
+
+=cut
+
+has chronicle_subscriber => (
+    is  => 'ro',
+    isa => 'Data::Chronicle::Subscriber'
+);
+
 has setting_namespace => (
     is      => 'ro',
     isa     => 'Str',
     default => 'app_settings',
 );
+
 has setting_name => (
     is       => 'ro',
     isa      => 'Str',
@@ -288,12 +311,9 @@ check and load updated settings from chronicle db
 sub check_for_update {
     my $self = shift;
 
-    # do fast cached check
-    my $now         = time;
-    my $prev_update = $self->_updated_at;
-    return if ($now - $prev_update < $self->refresh_interval);
+    return unless $self->_has_refresh_interval_passed();
+    $self->_updated_at(Time::HiRes::time());
 
-    $self->_updated_at($now);
     # do check in Redis
     my $data_set = $self->data_set;
     my $app_settings = $self->chronicle_reader->get($self->setting_namespace, $self->setting_name);
@@ -312,7 +332,7 @@ sub check_for_update {
 
 =head2 save_dynamic
 
-Save synamic settings into chronicle db
+Save dynamic settings into chronicle db
 
 =cut
 
@@ -329,7 +349,7 @@ sub save_dynamic {
     }
 
     $settings->{global} = $global->data;
-    $settings->{_rev}   = time;
+    $settings->{_rev}   = Time::HiRes::time();
     $self->chronicle_writer->set($self->setting_namespace, $self->setting_name, $settings, Date::Utility->new);
 
     return 1;
@@ -393,6 +413,397 @@ sub _add_dynamic_setting_info {
     return;
 }
 
+=head1 SUBROUTINES/METHODS
+######################################################
+###### Start new API
+######################################################
+
+=head2 local_caching
+
+If local_caching is set to the true then key-value pairs stored in Redis will be cached locally.
+
+Calling update_cache will update the local cache with any changes from Redis.
+refresh_interval defines (in seconds) the minimum time between seqequent updates.
+
+Calls to get on this object will only ever access the cache.
+Calls to set on this object will immediately update the values in the local cache and Redis.
+
+=cut
+
+has local_caching => (
+    isa     => 'Bool',
+    is      => 'ro',
+    default => 0,
+);
+
+=head2 update_cache
+
+Loads latest values from data chronicle into local cache.
+Calls to this method are rate-limited by C<refresh_interval>.
+
+=cut
+
+sub update_cache {
+    my $self = shift;
+    die 'Local caching not enabled' unless $self->local_caching;
+
+    return unless $self->_has_refresh_interval_passed();
+    $self->_updated_at(Time::HiRes::time());
+
+    return unless $self->_is_cache_stale();
+
+    my $keys = [$self->dynamic_keys(), '_global_rev'];
+    my @all_entries = $self->_retrieve_objects_from_chron($keys);
+    $self->_store_objects_in_cache({map { $keys->[$_] => $all_entries[$_] } (0 .. $#$keys)});
+
+    return 1;
+}
+
+sub _has_refresh_interval_passed {
+    my $self                   = shift;
+    my $now                    = Time::HiRes::time();
+    my $prev_update            = $self->_updated_at;
+    my $time_since_prev_update = $now - $prev_update;
+    return ($time_since_prev_update >= $self->refresh_interval);
+}
+
+sub _is_cache_stale {
+    my $self      = shift;
+    my @rev_cache = $self->_retrieve_objects_from_cache(['_global_rev']);
+    my @rev_chron = $self->_retrieve_objects_from_chron(['_global_rev']);
+    return !($rev_cache[0] && $rev_chron[0] && $rev_cache[0]->{data} eq $rev_chron[0]->{data});
+}
+
+=head2 global_revision
+
+Returns the global revision version of the config chronicle.
+This will correspond to the last time any of values were changed.
+
+=cut
+
+sub global_revision {
+    my $self = shift;
+    return $self->get('_global_rev');
+}
+
+=head2 set
+
+Takes a hashref of key->value pairs and atomically sets them in config chronicle
+
+Example:
+    set({key1 => 'value1', key2 => 'value2', key3 => 'value3',...});
+
+=cut
+
+sub set {
+    my ($self, $pairs) = @_;
+    my $rev_obj   = Date::Utility->new;
+    my $rev_epoch = $rev_obj->{epoch};
+
+    $self->_key_is_dynamic($_) or die "Cannot set with key: $_ | Key must be defined with 'global: 1'" foreach keys %$pairs;
+
+    $pairs->{_global_rev} = $rev_epoch;
+    my %key_objs_hash = pairmap { $a => {data => $b, _local_rev => $rev_epoch} } %$pairs;
+    $self->_store_objects(\%key_objs_hash, $rev_obj);
+
+    ######
+    # Temporary adapter code
+    ######
+    $self->data_set->{global}->set($_, $pairs->{$_}) foreach keys %$pairs;
+    $self->save_dynamic();
+
+    return 1;
+}
+
+sub _store_objects {
+    my ($self, $key_objs_hash, $date_obj, $optional_chron_args) = @_;
+    $self->_store_objects_in_chron($key_objs_hash, $date_obj, $optional_chron_args);
+    $self->_store_objects_in_cache($key_objs_hash) if $self->local_caching;
+    return 1;
+}
+
+sub _store_objects_in_cache {
+    my ($self, $key_objs_hash) = @_;
+    $self->{$_->key} = $_->value foreach (pairs %$key_objs_hash);
+    return 1;
+}
+
+sub _store_objects_in_chron {
+    my ($self, $key_objs_hash, $date_obj, $optional_chron_args) = @_;
+    my @atomic_write_pairs = pairmap { [$self->setting_namespace, $a, $b] } %$key_objs_hash;
+    $self->chronicle_writer->mset(\@atomic_write_pairs, $date_obj, @$optional_chron_args);
+    return 1;
+}
+
+=head2 get
+
+Takes either
+    - an arrayref of keys, gets them atomically, and returns a hashref of key->values,
+    including the global_revision under the key '_global_rev'.
+    - a single key (as a string), gets the value, and returns it directly.
+If a key has an empty value, it will return with undef.
+
+For convenience a get with just a key string will return the value only.
+
+Example:
+    get(['key1','key2','key3',...]);
+Returns:
+    {'key1' => 'value1', 'key2' => 'value2', 'key3' => 'value3',..., '_global_rev' => '<number>'}
+
+Example:
+    get(['key1']);
+Returns:
+    {'key1' => 'value1', '_global_rev' => '<number>'}
+
+Example:
+    get('key1');
+Returns:
+    'value1'
+
+=cut
+
+sub get {
+    my ($self, $keys) = @_;
+    my $single_get;
+
+    unless (ref $keys) {
+        $keys       = [$keys];
+        $single_get = 1;
+    }
+
+    $self->_key_exists($_) or die "Cannot get with key: $_ | Key must be defined" foreach @$keys;
+
+    push @$keys, '_global_rev' unless $single_get;
+
+    my @result_objs = $self->_retrieve_objects($keys);
+
+    if ($single_get) {
+        return $result_objs[0] ? $result_objs[0]->{data} : $self->get_default($keys->[0]);
+    } else {
+        return {map { $keys->[$_] => $result_objs[$_] ? $result_objs[$_]->{data} : $self->get_default($keys->[$_]) } (0 .. scalar @$keys - 1)};
+    }
+}
+
+sub _retrieve_objects {
+    my ($self, $keys) = @_;
+    return $self->_retrieve_objects_from_cache($keys) if $self->local_caching;
+    return $self->_retrieve_objects_from_chron($keys);
+}
+
+sub _retrieve_objects_from_cache {
+    my ($self, $keys) = @_;
+    return map { $self->{$_} } @$keys;
+}
+
+sub _retrieve_objects_from_chron {
+    my ($self, $keys) = @_;
+    my @atomic_read_pairs = map { [$self->setting_namespace, $_] } @$keys;
+    return $self->chronicle_reader->mget(\@atomic_read_pairs);
+}
+
+=head2 get_history
+
+Retreives a past revision of an app config entry, where $rev is the number of revisions in the past requested.
+If the optional third argument is true then result of the query will be cached in Redis. This is useful if a certain
+    revision will be needed repeatedly, to avoid excessive database access. By default this argument is 0.
+All cached revisions will become stale if the key is set with a new value.
+
+Example:
+    get_history('system.email', 0); Retrieves current version
+    get_history('system.email', 1); Retreives previous revision
+    get_history('system.email', 2); Retreives version before previous
+
+=cut
+
+sub get_history {
+    my ($self, $key, $rev, $cache) = @_;
+    $cache //= 0;
+
+    die "Cannot get history of key: $key | Key must be dynamic" unless $self->_key_is_dynamic($key);
+
+    my ($curr_obj, $hist_obj) = $self->_retrieve_objects([$key, $key . '::' . $rev]);
+
+    # If no cache, or cache is stale, get from db
+    unless ($hist_obj && $hist_obj->{_local_rev} == $curr_obj->{_local_rev}) {
+        $hist_obj = $self->chronicle_reader->get_history($self->setting_namespace, $key, $rev);
+
+        $hist_obj->{_local_rev} = $curr_obj->{_local_rev} if $hist_obj;
+        $self->_store_objects(
+            {$key . '::' . $rev => $hist_obj},
+            Date::Utility->new,
+            [
+                0,                    #<-- IMPORTANT: disables archiving
+                0,                    #<-- IMPORTANT: supresses publication
+                REDIS_HISTORY_TTL,    #<-- ttl = 7 days so that stale histories don't stay indefinitely.
+            ]) if $hist_obj && $cache;
+    }
+    return $hist_obj->{data} if $hist_obj;
+    return undef;
+}
+
+=head2 subscribe
+
+Subscribes to changes for the specified $key with the sub $subref called when a new value is set.
+The chronicle_writer must have publish_on_set enabled.
+
+=cut
+
+sub subscribe {
+    my ($self, $key, $subref) = @_;
+    die 'Cannot subscribe without chronicle_subscriber' unless $self->chronicle_subscriber;
+    return $self->chronicle_subscriber->subscribe($self->setting_namespace, $key, $subref);
+}
+
+=head2 unsubscribe
+
+Stops the sub $subref from being called when $key is set with a new value.
+The chronicle_writer must have publish_on_set enabled.
+
+=cut
+
+sub unsubscribe {
+    my ($self, $key) = @_;
+    die 'Cannot unsubscribe without chronicle_subscriber' unless $self->chronicle_subscriber;
+    return $self->chronicle_subscriber->unsubscribe($self->setting_namespace, $key);
+}
+
+has _keys_schema => (
+    is      => 'ro',
+    isa     => 'HashRef',
+    default => sub { {} },
+);
+
+=head2 all_keys
+
+Returns a list containing all keys in the config chronicle schema
+
+=cut
+
+sub all_keys {
+    my $self = shift;
+    return grep { not $self->_key_is_internal($_) } keys %{$self->_keys_schema};
+}
+
+=head2 dynamic_keys
+
+Returns a list containing only the dynamic keys in the config chronicle schema
+
+=cut
+
+sub dynamic_keys {
+    my $self = shift;
+    return grep { $self->_key_is_dynamic($_) } keys %{$self->_keys_schema};
+}
+
+=head2 static_keys
+
+Returns a list containing only the static keys in the config chronicle schema
+
+=cut
+
+sub static_keys {
+    my $self = shift;
+    return grep { $self->_key_is_static($_) } keys %{$self->_keys_schema};
+}
+
+=head2 get_data_type
+
+Returns the data type associated with a particular key
+
+=cut
+
+sub get_data_type {
+    my ($self, $key) = @_;
+    return unless $self->_key_exists($key);
+    return $self->_keys_schema->{$key}->{data_type};
+}
+
+=head2 get_default
+
+Returns the default value associated with a particular key
+
+=cut
+
+sub get_default {
+    my ($self, $key) = @_;
+    return unless $self->_key_exists($key);
+    return $self->_keys_schema->{$key}->{default};
+}
+
+=head2 get_description
+
+Returns the default value associated with a particular key
+
+=cut
+
+sub get_description {
+    my ($self, $key) = @_;
+    return unless $self->_key_exists($key);
+    return $self->_keys_schema->{$key}->{description};
+}
+
+=head2 get_key_type
+
+Returns the key type associated with a particular key
+
+=cut
+
+sub get_key_type {
+    my ($self, $key) = @_;
+    return unless $self->_key_exists($key);
+    return $self->_keys_schema->{$key}->{key_type};
+}
+
+sub _key_exists {
+    my ($self, $key) = @_;
+    return exists $self->_keys_schema->{$key};
+}
+
+sub _key_is_dynamic {
+    my ($self, $key) = @_;
+    return exists $self->_keys_schema->{$key} && $self->_keys_schema->{$key}->{key_type} eq 'dynamic';
+}
+
+sub _key_is_static {
+    my ($self, $key) = @_;
+    return exists $self->_keys_schema->{$key} && $self->_keys_schema->{$key}->{key_type} eq 'static';
+}
+
+sub _key_is_internal {
+    my ($self, $key) = @_;
+    return exists $self->_keys_schema->{$key} && $self->_keys_schema->{$key}->{key_type} eq 'internal';
+}
+
+sub _initialise {
+    my ($self, $keys, $path) = @_;
+
+    foreach my $key (keys %{$keys}) {
+        my $def = $keys->{$key};
+        my $fully_qualified_path = $path ? $path . '.' . $key : $key;
+
+        if ($def->{isa} eq 'section') {
+            $self->_initialise($def->{contains}, $fully_qualified_path);
+        } else {
+            $self->_keys_schema->{$fully_qualified_path} = {
+                key_type => $def->{global} ? 'dynamic' : 'static',
+                data_type   => $def->{isa},
+                default     => $def->{default},
+                description => $def->{description},
+            };
+        }
+    }
+    $self->_keys_schema->{_global_rev} = {
+        key_type  => 'internal',
+        data_type => 'Num',
+        default   => 0,
+    };
+    return 1;
+}
+
+######################################################
+###### End new API
+######################################################
+
 =head2 BUILD
 
 =cut
@@ -401,6 +812,7 @@ sub BUILD {
     my $self = shift;
 
     $self->_build_class;
+    $self->_initialise($self->_defdb, '');
 
     return;
 }

--- a/t/08_new_api.t
+++ b/t/08_new_api.t
@@ -1,0 +1,311 @@
+use Test::Most;
+use Test::Warn;
+use Test::MockModule;
+use Test::MockTime qw( :all );
+use Data::Chronicle::Mock;
+use App::Config::Chronicle;
+use FindBin qw($Bin);
+
+use constant {
+    EMAIL_KEY     => 'system.email',
+    FIRST_EMAIL   => 'abc@test.com',
+    SECOND_EMAIL  => 'def@test.com',
+    THIRD_EMAIL   => 'ghi@test.com',
+    DEFAULT_EMAIL => 'dummy@email.com',
+    ADMINS_KEY    => 'system.admins',
+    ADMINS_SET    => ['john', 'bob', 'jane', 'susan'],
+    REFRESH_KEY   => 'system.refresh',
+    REFRESH_SET   => 20,
+    DEFAULT_REF   => 10,
+    NON_EXT_KEY   => 'system.wrong'
+};
+
+my $tick = 0;
+set_fixed_time($tick);
+*Time::HiRes::time = \&Test::MockTime::time;
+
+subtest 'Global revision = 0' => sub {
+    my $app_config = _new_app_config();
+    is $app_config->global_revision(), 0, 'Brand new app config returns 0 revision';
+};
+
+subtest 'Cannot externally set global_revision' => sub {
+    my $app_config = _new_app_config();
+    throws_ok {
+        $app_config->set({'_global_rev' => 1});
+    }
+    qr/Cannot set with key/;
+};
+
+subtest 'Dynamic keys' => sub {
+    my $app_config = _new_app_config();
+    my @keys       = $app_config->dynamic_keys;
+    is_deeply [sort @keys], [EMAIL_KEY, REFRESH_KEY], 'Keys are listed correctly';
+};
+
+subtest 'Static keys' => sub {
+    my $app_config = _new_app_config();
+    my @keys       = $app_config->static_keys;
+    is_deeply [sort @keys], [ADMINS_KEY], 'Keys are listed correctly';
+};
+
+subtest 'All keys' => sub {
+    my $app_config = _new_app_config();
+    my @keys       = $app_config->all_keys();
+    is_deeply [sort @keys], [ADMINS_KEY, EMAIL_KEY, REFRESH_KEY], 'Keys are listed correctly';
+};
+
+subtest 'Default values' => sub {
+    my $app_config = _new_app_config();
+    is $app_config->get(EMAIL_KEY),   DEFAULT_EMAIL, 'Default email is returned';
+    is $app_config->get(REFRESH_KEY), DEFAULT_REF,   'Default refresh is returned';
+    is_deeply $app_config->get(ADMINS_KEY), [], 'Default admins are returned';
+
+    ok my $multi = $app_config->get([EMAIL_KEY, REFRESH_KEY]), 'Mget defaults is ok';
+    is $multi->{EMAIL_KEY()},   DEFAULT_EMAIL, 'Default email is returned';
+    is $multi->{REFRESH_KEY()}, DEFAULT_REF,   'Default refresh is returned';
+};
+
+subtest 'Check types' => sub {
+    my $app_config = _new_app_config();
+    is $app_config->get_data_type(NON_EXT_KEY), undef,      'Bad key returns nothing';
+    is $app_config->get_data_type(EMAIL_KEY),   'Str',      'Email type is correct';
+    is $app_config->get_data_type(ADMINS_KEY),  'ArrayRef', 'Admins type is correct';
+    is $app_config->get_data_type(REFRESH_KEY), 'Num',      'Refresh rate type is correct';
+};
+
+subtest 'Check key types' => sub {
+    my $app_config = _new_app_config();
+    is $app_config->get_key_type(NON_EXT_KEY), undef,     'Bad key returns nothing';
+    is $app_config->get_key_type(EMAIL_KEY),   'dynamic', 'Email type is correct';
+    is $app_config->get_key_type(ADMINS_KEY),  'static',  'Admins type is correct';
+    is $app_config->get_key_type(REFRESH_KEY), 'dynamic', 'Refresh rate type is correct';
+};
+
+subtest 'Basic set and get' => sub {
+    my $app_config = _new_app_config();
+
+    ok $app_config->set({EMAIL_KEY() => FIRST_EMAIL}), 'Set 1 value succeeds';
+    is $app_config->get(EMAIL_KEY), FIRST_EMAIL, 'Email is retrieved successfully';
+};
+
+subtest 'Batch set and get' => sub {
+    my $app_config = _new_app_config();
+
+    ok $app_config->set({
+            EMAIL_KEY()   => FIRST_EMAIL,
+            REFRESH_KEY() => REFRESH_SET
+        }
+        ),
+        'Set 2 values succeeds';
+
+    ok my $res = $app_config->get([EMAIL_KEY, REFRESH_KEY]);
+    is $res->{EMAIL_KEY()},   FIRST_EMAIL, 'Email is retrieved successfully';
+    is $res->{REFRESH_KEY()}, REFRESH_SET, 'Refresh is retrieved successfully';
+    exists $res->{'_global_rev'}, 'Batch get returns global revision';
+};
+
+subtest 'Gets/sets of illegal keys' => sub {
+    subtest 'Attempt to set static key' => sub {
+        my $app_config = _new_app_config();
+        throws_ok {
+            $app_config->set({ADMINS_KEY() => ADMINS_SET});
+        }
+        qr/Cannot set with key/;
+    };
+
+    subtest 'Attempt to set non-existent key' => sub {
+        my $app_config = _new_app_config();
+        throws_ok {
+            $app_config->set({NON_EXT_KEY() => ADMINS_SET});
+        }
+        qr/Cannot set with key/;
+    };
+
+    subtest 'Attempt to get non-existent key' => sub {
+        my $app_config = _new_app_config();
+        throws_ok {
+            $app_config->get(NON_EXT_KEY);
+        }
+        qr/Cannot get with key/;
+    };
+};
+
+subtest 'History chronicling' => sub {
+    my $app_config = _new_app_config();
+    my $module     = Test::MockModule->new('Data::Chronicle::Reader');
+
+    subtest 'Add history of values' => sub {
+        set_fixed_time(++$tick);
+        ok $app_config->set({EMAIL_KEY() => FIRST_EMAIL}), 'Set 1st value succeeds';
+        set_fixed_time(++$tick);
+        ok $app_config->set({EMAIL_KEY() => SECOND_EMAIL}), 'Set 2nd value succeeds';
+        set_fixed_time(++$tick);
+        ok $app_config->set({EMAIL_KEY() => THIRD_EMAIL}), 'Set 3rd value succeeds';
+        set_fixed_time(++$tick);
+    };
+
+    subtest 'Get history' => sub {
+        is($app_config->get_history(EMAIL_KEY, 0, 1), THIRD_EMAIL,  'History retrieved successfully');
+        is($app_config->get_history(EMAIL_KEY, 1, 1), SECOND_EMAIL, 'History retrieved successfully');
+        is($app_config->get_history(EMAIL_KEY, 2, 1), FIRST_EMAIL,  'History retrieved successfully');
+    };
+
+    subtest 'Ensure get_history is cached (i.e. get_history should not be called)' => sub {
+        $module->mock('get_history', sub { ok(0, 'get_history should not be called here') });
+        is($app_config->get_history(EMAIL_KEY, 0), THIRD_EMAIL,  'Email retrieved via cache');
+        is($app_config->get_history(EMAIL_KEY, 1), SECOND_EMAIL, 'Email retrieved via cache');
+        is($app_config->get_history(EMAIL_KEY, 2), FIRST_EMAIL,  'Email retrieved via cache');
+        $module->unmock('get_history');
+    };
+
+    subtest 'Ensure cache goes stale when new is set' => sub {
+        is($app_config->get_history(EMAIL_KEY, 1, 1), SECOND_EMAIL, 'Previous email is correct');
+        ok $app_config->set({EMAIL_KEY() => FIRST_EMAIL}), 'Set email succeeds';
+        is($app_config->get_history(EMAIL_KEY, 1), THIRD_EMAIL, 'Correct previous email is returned');
+    };
+
+    subtest 'Check caching can be disabled' => sub {
+        my $get_history_called;
+
+        $app_config = _new_app_config();
+        $module->mock('get_history', sub { $get_history_called++; return {data => SECOND_EMAIL} });
+        is($app_config->get_history(EMAIL_KEY, 2), SECOND_EMAIL, 'Email retrieved via chronicle');
+        is($app_config->get_history(EMAIL_KEY, 2), SECOND_EMAIL, 'Email retrieved via chronicle again');
+        $module->unmock('get_history');
+
+        is $get_history_called, 2, 'get_history was called twice';
+    };
+
+    subtest 'Rev too old' => sub {
+        is($app_config->get_history(EMAIL_KEY, 50), undef, 'Rev older than oldest returns undef');
+    };
+
+    subtest 'History of static key' => sub {
+        throws_ok {
+            $app_config->get_history(ADMINS_KEY, 1);
+        }
+        qr/Cannot get history/;
+    };
+};
+
+subtest 'Perl level caching' => sub {
+    subtest "Chronicle shouldn't be engaged with perl caching enabled" => sub {
+        my $app_config = _new_app_config(local_caching => 1);
+
+        ok $app_config->set({EMAIL_KEY() => FIRST_EMAIL}), 'Set email to chron';
+
+        my $reader_module = Test::MockModule->new('Data::Chronicle::Reader');
+        $reader_module->mock('get',  sub { ok(0, 'get should not be called here') });
+        $reader_module->mock('mget', sub { ok(0, 'mget should not be called here') });
+
+        is $app_config->get(EMAIL_KEY), FIRST_EMAIL, 'Email is retrieved without chron access';
+
+        $reader_module->unmock('get');
+        $reader_module->unmock('mget');
+    };
+
+    subtest 'Chronicle should be engaged with perl caching disabled' => sub {
+        my $chronicle_gets;
+        my $app_config = _new_app_config(local_caching => 0);
+
+        my $reader_module = Test::MockModule->new('Data::Chronicle::Reader');
+        $reader_module->mock('get',  sub { $chronicle_gets++; return {data => FIRST_EMAIL} });
+        $reader_module->mock('mget', sub { $chronicle_gets++; return {data => FIRST_EMAIL} });
+
+        ok $app_config->set({EMAIL_KEY() => FIRST_EMAIL}), 'Set email with write to chron';
+        is $app_config->get(EMAIL_KEY), FIRST_EMAIL, 'Email is retrieved with chron access';
+
+        ok $chronicle_gets, 'get engages chronicle';
+
+        $reader_module->unmock('get');
+        $reader_module->unmock('mget');
+    };
+};
+
+subtest 'Global revision updates' => sub {
+    my $app_config = _new_app_config();
+    my $old_rev    = $app_config->global_revision();
+
+    set_fixed_time(++$tick);
+    ok $app_config->set({EMAIL_KEY() => FIRST_EMAIL}), 'Set 1 value succeeds';
+
+    my $new_rev = $app_config->global_revision();
+    ok $new_rev > $old_rev, 'Revision was increased';
+};
+
+subtest 'Cache syncing' => sub {
+    my $cached_config1 = _new_app_config(
+        local_caching    => 1,
+        refresh_interval => 0
+    );
+    my $cached_config2 = _new_app_config(
+        local_caching    => 1,
+        refresh_interval => 0
+    );
+    my $direct_config = _new_app_config(local_caching => 0);
+
+    ok $direct_config->set({EMAIL_KEY() => FIRST_EMAIL}), 'Set email succeeds';
+    is $direct_config->get(EMAIL_KEY),  FIRST_EMAIL,   'Email is retrieved successfully';
+    is $cached_config1->get(EMAIL_KEY), DEFAULT_EMAIL, 'Cache1 contains default before first update call';
+    is $cached_config2->get(EMAIL_KEY), DEFAULT_EMAIL, 'Cache2 contains default before first update call';
+
+    ok $cached_config1->update_cache(), 'Cache 1 is updated';
+    ok $cached_config2->update_cache(), 'Cache 2 is updated';
+    is $cached_config1->get(EMAIL_KEY), FIRST_EMAIL, 'Cache1 is updated with email';
+    is $cached_config2->get(EMAIL_KEY), FIRST_EMAIL, 'Cache2 is updated with email';
+
+    set_fixed_time(++$tick);    #Ensure new value is recorded at a different time
+    ok $cached_config1->set({EMAIL_KEY() => SECOND_EMAIL}), 'Set email via cache 1 succeeds';
+    is $direct_config->get(EMAIL_KEY),  SECOND_EMAIL, 'Email is retrieved directly';
+    is $cached_config1->get(EMAIL_KEY), SECOND_EMAIL, 'Cache1 has updated email';
+    is $cached_config2->get(EMAIL_KEY), FIRST_EMAIL,  'Cache2 still has old email';
+
+    ok $cached_config2->update_cache(), 'Cache 2 is updated';
+    is $cached_config2->get(EMAIL_KEY), SECOND_EMAIL, 'Cache2 has updated email';
+};
+
+subtest 'Cache refresh_interval' => sub {
+    my $cached_config = _new_app_config(
+        local_caching    => 1,
+        refresh_interval => 2
+    );
+    my $direct_config = _new_app_config(local_caching => 0);
+
+    set_fixed_time(++$tick);    #Ensure new value is recorded at a different time
+    ok $direct_config->set({EMAIL_KEY() => FIRST_EMAIL}), 'Set email succeeds';
+    is $direct_config->get(EMAIL_KEY), FIRST_EMAIL, 'Email is retrieved successfully';
+    ok $cached_config->update_cache(), 'Cache is updated';
+    is $cached_config->get(EMAIL_KEY), FIRST_EMAIL, 'Email is retrieved successfully';
+
+    set_fixed_time(++$tick);    #Ensure new value is recorded at a different time
+    ok $direct_config->set({EMAIL_KEY() => SECOND_EMAIL}), 'Set email succeeds';
+    is $direct_config->get(EMAIL_KEY), SECOND_EMAIL, 'Email is retrieved successfully';
+    ok !$cached_config->update_cache(), 'update not done due to refresh_interval';
+    is $cached_config->get(EMAIL_KEY), FIRST_EMAIL, "Cache still has old value since interval hasn't passed";
+
+    set_fixed_time($tick + $cached_config->refresh_interval);
+    ok $cached_config->update_cache(), 'Cache is updated';
+    is $cached_config->get(EMAIL_KEY), SECOND_EMAIL, 'Email is retrieved successfully from updated cache';
+};
+
+sub _new_app_config {
+    my $app_config;
+    my %options = @_;
+
+    subtest 'Setup' => sub {
+        my ($chronicle_r, $chronicle_w) = Data::Chronicle::Mock::get_mocked_chronicle();
+        lives_ok {
+            $app_config = App::Config::Chronicle->new(
+                definition_yml   => "$Bin/test.yml",
+                chronicle_reader => $chronicle_r,
+                chronicle_writer => $chronicle_w,
+                %options
+            );
+        }
+        'We are living';
+    };
+    return $app_config;
+}
+
+done_testing;

--- a/t/test.yml
+++ b/t/test.yml
@@ -7,6 +7,11 @@ system:
       isa: Str
       default: "dummy@email.com"
       global: 1
+    refresh:
+      description: "System refresh rate"
+      isa: Num
+      default: 10
+      global: 1
     admins:
       description: "Admin list"
       isa: ArrayRef

--- a/xt/boilerplate.t
+++ b/xt/boilerplate.t
@@ -8,7 +8,7 @@ plan tests => 3;
 
 sub not_in_file_ok {
     my ($filename, %regex) = @_;
-    open( my $fh, '<', $filename )
+    open(my $fh, '<', $filename)
         or die "couldn't open $filename for reading: $!";
 
     my %violated;
@@ -16,7 +16,7 @@ sub not_in_file_ok {
     while (my $line = <$fh>) {
         while (my ($desc, $regex) = each %regex) {
             if ($line =~ $regex) {
-                push @{$violated{$desc}||=[]}, $.;
+                push @{$violated{$desc} ||= []}, $.;
             }
         }
     }
@@ -31,27 +31,24 @@ sub not_in_file_ok {
 
 sub module_boilerplate_ok {
     my ($module) = @_;
-    not_in_file_ok($module =>
-        'the great new $MODULENAME'   => qr/ - The great new /,
-        'boilerplate description'     => qr/Quick summary of what the module/,
-        'stub function definition'    => qr/function[12]/,
+    not_in_file_ok(
+        $module                    => 'the great new $MODULENAME' => qr/ - The great new /,
+        'boilerplate description'  => qr/Quick summary of what the module/,
+        'stub function definition' => qr/function[12]/,
     );
 }
 
 TODO: {
-  local $TODO = "Need to replace the boilerplate text";
+    local $TODO = "Need to replace the boilerplate text";
 
-  not_in_file_ok(README =>
-    "The README is used..."       => qr/The README is used/,
-    "'version information here'"  => qr/to provide version information/,
-  );
+    not_in_file_ok(
+        README                       => "The README is used..." => qr/The README is used/,
+        "'version information here'" => qr/to provide version information/,
+    );
 
-  not_in_file_ok(Changes =>
-    "placeholder date/time"       => qr(Date/time)
-  );
+    not_in_file_ok(Changes => "placeholder date/time" => qr(Date/time));
 
-  module_boilerplate_ok('lib/App/Config/Chronicle.pm');
-
+    module_boilerplate_ok('lib/App/Config/Chronicle.pm');
 
 }
 


### PR DESCRIPTION
* added individual setting storage and support for history requests

* fixed typos

* removed test line re change in perl-data-chronicle behaviour

* fixed typo

* added code for history caching

* added comment

* added tests for history caching

* added comments

* added sub and unsub calls

* setting up new api

* starting new tests

* migrating to new api

* revmoved unreleased data chron from old test

* fixed error messages

* improved testing

* added test for perl caching

* changed chronicle object to hash

* set rev for each setting

* removed redundant app config creator

* global revision

* Added sub to get dynamic keys

* untested sync code

* set always writes to chron

* simplified cache for only get use

* fixed errors

* updated tests for get only caching

* added caching tests and tidy

* refresh interval for new cache update

* enforcing only editing of dynamic settings

* setup key storage

* initialise default values (needs code work) and moved history cache clearing

* tidy;

* tidying cache update

* finished tidy of cache update

* reorganised sub order

* tided set

* tidied get

* tidied get history

* fix

* caching history inside obj itself

* started refactor

* removed legacy connector

* changed label to local_rev

* changed label t gloal_rev

* shifted sub ubsub to chron

* finished refactor of sets

* tidy;

* refactored gets

* added key checks;

* refactored rev

* refactored get history

* refactored defaults

* removed todo comment

* refactored get history

* put key check in get history method

* test for history rev older than oldest

* removed old integration code

* added documentation

* set ttl for hist caches and refactored update cache

* refactored get

* added type storage

* fixed comments

* refactored key storage

* added simple get back

* moved defaults and removed use of setnx

* removed local libs

* code review comments

* code review

* fixed List Util version requirement

* import versions

* added version and changes

* run tests

* sort keys for test consistency

* added returns

* renamed schema hash and made get defaults private

* altered public private subs

* fix codecov

* added pod comments;

* updated data chronicle to v0.18

* added chron subscriber

* perltidy

* swicth subscribe subs to cache_subscriber

* fix unused var

* made get default public and added description

* fix for default calls

* added temp code to push changes to old struct

* added get_key_type sub

* enforced internality of global rev key

* added temp test workaround

* doc changes

* tidy

* fixed eol

* code review changes

* changed rest of times

* version fixes

* review fixes

* review fixes

* added missing pod

* fix head

* moved to time mocking

* added returns

* switch chron access check style

* added mocktime to cpan

* fix test so not to be impacted by adapter

* reverted manual ver change

* fix doc comments for global rev

* return list fix